### PR TITLE
Improve scoreboard layout responsiveness

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -76,15 +76,63 @@ local function setupStripes(height)
     end
 end
 
+local function computeHudSpacing()
+    local smallHeight = fonts.small and fonts.small:getHeight() or 22
+    local titleHeight = fonts.h2 and fonts.h2:getHeight() or 48
+    local paddingTop = math.max(24, smallHeight * 0.9)
+    local paddingBottom = math.max(28, smallHeight * 0.9)
+    local headerGap = math.max(18, smallHeight * 0.6)
+    local rowGap = math.max(16, smallHeight * 0.55)
+
+    local spacing = {
+        paddingTop = paddingTop,
+        paddingBottom = paddingBottom,
+        headerGap = headerGap,
+        rowGap = rowGap,
+        titleHeight = titleHeight,
+        headerHeight = smallHeight,
+        rowHeight = smallHeight,
+    }
+
+    spacing.totalHeight = spacing.paddingTop + spacing.titleHeight + spacing.headerGap
+        + spacing.headerHeight + spacing.rowHeight * 3 + spacing.rowGap * 3 + spacing.paddingBottom
+
+    return spacing
+end
+
 local function setupLayout(width, height)
     -- Board centrata, ma lasciamo spazio sopra per HUD e sotto per pulsanti
     local marginY = math.max(32, height * 0.08)
     local marginX = math.max(24, width * 0.05)
-    local usableHeight = height - marginY * 2 - 180 -- spazio per HUD e pulsanti
-    local boardWidth = math.min(width - marginX * 2, usableHeight * (4 / 3))
+
+    local hudSpacing = computeHudSpacing()
+    local hudWidth = math.min(math.max(360, width * 0.42), width - marginX * 2)
+    local hudY = marginY
+    game.layout.hud = {
+        x = (width - hudWidth) / 2,
+        y = hudY,
+        w = hudWidth,
+        h = hudSpacing.totalHeight,
+    }
+    game.layout.hudSpacing = hudSpacing
+
+    local hudToBoardSpacing = math.max(40, height * 0.04)
+    local footerSpace = 180
+    local usableHeight = height - marginY * 2 - hudSpacing.totalHeight - hudToBoardSpacing - footerSpace
+    local maxBoardHeight = math.max(usableHeight, height * 0.3)
+
+    local boardWidth = math.min(width - marginX * 2, maxBoardHeight * (4 / 3))
     local boardHeight = boardWidth * (3 / 4)
+    if boardHeight > maxBoardHeight then
+        boardHeight = maxBoardHeight
+        boardWidth = boardHeight * (4 / 3)
+        if boardWidth > width - marginX * 2 then
+            boardWidth = width - marginX * 2
+            boardHeight = boardWidth * (3 / 4)
+        end
+    end
     local boardX = (width - boardWidth) / 2
-    local boardY = marginY + 100 -- sotto l'HUD
+    local boardY = hudY + hudSpacing.totalHeight + hudToBoardSpacing
 
     game.layout.board = {x = boardX, y = boardY, w = boardWidth, h = boardHeight}
     game.layout.hingeY = boardY + boardHeight * 0.68
@@ -119,14 +167,6 @@ local function setupLayout(width, height)
         y = game.layout.trays.player.y,
         w = keptSpacing - 16,
         h = trayHeight,
-    }
-
-    -- HUD centrato in alto
-    game.layout.hud = {
-        x = (width - 340) / 2,
-        y = marginY,
-        w = 340,
-        h = 150,
     }
 
     -- Messaggio centrato sotto la board
@@ -449,6 +489,7 @@ end
 
 local function drawHUD()
     local hud = game.layout.hud
+    local spacing = game.layout.hudSpacing or computeHudSpacing()
     love.graphics.setColor(0.13, 0.10, 0.08, 0.92)
     love.graphics.rectangle("fill", hud.x, hud.y, hud.w, hud.h, 18, 18)
     love.graphics.setColor(0.35, 0.27, 0.18)
@@ -458,49 +499,69 @@ local function drawHUD()
     -- Titolo
     love.graphics.setFont(fonts.h2)
     love.graphics.setColor(0.98, 0.95, 0.85)
-    love.graphics.printf("SCOREBOARD", hud.x, hud.y + 8, hud.w, "center")
+    local y = hud.y + spacing.paddingTop
+    love.graphics.printf("SCOREBOARD", hud.x, y, hud.w, "center")
 
     -- Header
-    local rowY = hud.y + 44
-    local colX = {hud.x + 18, hud.x + 120, hud.x + 210, hud.x + 290}
+    y = y + spacing.titleHeight + spacing.headerGap
+    local headerY = y
+    local paddingX = math.max(18, hud.w * 0.06)
+    local availableWidth = hud.w - paddingX * 2
+    local colWidths = {
+        availableWidth * 0.38,
+        availableWidth * 0.22,
+        availableWidth * 0.20,
+        availableWidth * 0.20,
+    }
+    local colX = {
+        hud.x + paddingX,
+        hud.x + paddingX + colWidths[1],
+        hud.x + paddingX + colWidths[1] + colWidths[2],
+        hud.x + paddingX + colWidths[1] + colWidths[2] + colWidths[3],
+    }
     love.graphics.setFont(fonts.small)
     love.graphics.setColor(0.85, 0.82, 0.7)
-    love.graphics.print("Player", colX[1], rowY)
-    love.graphics.print("Banked", colX[2], rowY)
-    love.graphics.print("Round", colX[3], rowY)
-    love.graphics.print("Selected", colX[4], rowY)
+    love.graphics.print("Player", colX[1], headerY)
+    love.graphics.printf("Banked", colX[2], headerY, colWidths[2], "right")
+    love.graphics.printf("Round", colX[3], headerY, colWidths[3], "right")
+    love.graphics.printf("Selected", colX[4], headerY, colWidths[4], "right")
 
     -- Riga 1: Player
-    rowY = rowY + 28
+    local headerBottom = headerY + spacing.headerHeight
+    local rowY = headerBottom + spacing.rowGap
     love.graphics.setColor(0.7, 0.85, 1.0)
     love.graphics.print(game.players[1].name, colX[1], rowY)
     love.graphics.setColor(1, 1, 1)
-    love.graphics.printf(tostring(game.players[1].banked), colX[2], rowY, 80, "right")
+    love.graphics.printf(tostring(game.players[1].banked), colX[2], rowY, colWidths[2], "right")
     love.graphics.setColor(0.72, 0.9, 0.9)
-    love.graphics.printf(tostring(game.roundScore), colX[3], rowY, 70, "right")
+    love.graphics.printf(tostring(game.roundScore), colX[3], rowY, colWidths[3], "right")
     love.graphics.setColor(0.9, 0.75, 0.4)
-    love.graphics.printf(tostring(game.selection.points), colX[4], rowY, 60, "right")
+    love.graphics.printf(tostring(game.selection.points), colX[4], rowY, colWidths[4], "right")
 
     -- Riga 2: AI
-    rowY = rowY + 28
+    rowY = rowY + spacing.rowHeight + spacing.rowGap
     love.graphics.setColor(1.0, 0.6, 0.55)
     love.graphics.print(game.players[2].name, colX[1], rowY)
     love.graphics.setColor(1, 1, 1)
-    love.graphics.printf(tostring(game.players[2].banked), colX[2], rowY, 80, "right")
+    love.graphics.printf(tostring(game.players[2].banked), colX[2], rowY, colWidths[2], "right")
     -- Round e Selected per AI lasciati vuoti
 
+    local row2Bottom = rowY + spacing.rowHeight
+
     -- Riga 3: Goal
-    rowY = rowY + 28
+    rowY = rowY + spacing.rowHeight + spacing.rowGap
     love.graphics.setColor(0.95, 0.88, 0.45)
     love.graphics.print("Goal", colX[1], rowY)
     love.graphics.setColor(1, 1, 1)
-    love.graphics.printf(tostring(winningScore), colX[2], rowY, 80, "right")
+    love.graphics.printf(tostring(winningScore), colX[2], rowY, colWidths[2], "right")
 
     -- Separatore
     love.graphics.setColor(0.35, 0.27, 0.18, 0.7)
     love.graphics.setLineWidth(1)
-    love.graphics.line(hud.x + 12, hud.y + 40, hud.x + hud.w - 12, hud.y + 40)
-    love.graphics.line(hud.x + 12, hud.y + 100, hud.x + hud.w - 12, hud.y + 100)
+    local line1Y = headerBottom + spacing.rowGap * 0.5
+    local line2Y = row2Bottom + spacing.rowGap * 0.5
+    love.graphics.line(hud.x + 12, line1Y, hud.x + hud.w - 12, line1Y)
+    love.graphics.line(hud.x + 12, line2Y, hud.x + hud.w - 12, line2Y)
 end
 
 local function drawMessage()
@@ -813,8 +874,8 @@ end
 function love.load()
     love.math.setRandomSeed(os.time())
     local width, height = love.graphics.getDimensions()
-    setupLayout(width, height)
     refreshFonts(width, height)
+    setupLayout(width, height)
     setupStripes(height)
     decodeCursor()
     loadSelectionImages()
@@ -897,7 +958,7 @@ function love.mousepressed(x, y, button)
 end
 
 function love.resize(width, height)
-    setupLayout(width, height)
     refreshFonts(width, height)
+    setupLayout(width, height)
     setupStripes(height)
 end


### PR DESCRIPTION
## Summary
- compute HUD spacing from font metrics and resize the scoreboard dynamically so the columns no longer overlap at large resolutions
- adjust the playfield layout to account for the taller HUD and keep the board, trays, and buttons aligned after resizing

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e671b67514832789d4a76cf73ef657