### PR TITLE
Fix scoring validation and unstick AI turns

### DIFF
--- a/lib/scoring.lua
+++ b/lib/scoring.lua
@@ -33,58 +33,129 @@ end
 S.basePoints = basePoints
 
 function S.scoreSelection(vals)
+  if #vals == 0 then
+    return {points = 0, valid = false}
+  end
+
   local c = S.counts(vals)
   local used = {0,0,0,0,0,0,0}
   local points = 0
 
-  -- 1+2+3+4+5+6 = 1500
-  if #vals == 6 and c[1]==1 and c[2]==1 and c[3]==1 and c[4]==1 and c[5]==1 and c[6]==1 then
-    points = points + 1500
-    for i=1,6 do used[i]=used[i]+1 end
+  local function use(face, amount)
+    used[face] = used[face] + amount
   end
 
-  -- 1+2+3+4+5 = 500
-  if c[1]>=1 and c[2]>=1 and c[3]>=1 and c[4]>=1 and c[5]>=1 then
-    points = points + 500
-    for i=1,5 do used[i]=used[i]+1 end
-  end
+  if #vals == 6 then
+    if hasFaces(c, {1,2,3,4,5,6}) then
+      return {points = 1500, valid = true}
+    end
 
-  -- 2+3+4+5+6 = 750
-  if c[2]>=1 and c[3]>=1 and c[4]>=1 and c[5]>=1 and c[6]>=1 then
-    points = points + 750
-    for i=2,6 do used[i]=used[i]+1 end
-  end
+    local pairFaces = {}
+    local invalidThreePairs = false
+    for face = 1, 6 do
+      if c[face] == 2 then
+        pairFaces[#pairFaces + 1] = face
+      elseif c[face] ~= 0 and c[face] ~= 2 then
+        invalidThreePairs = true
+      end
+    end
+    if not invalidThreePairs and #pairFaces == 3 then
+      for _, face in ipairs(pairFaces) do
+        use(face, 2)
+      end
+      return {points = 1500, valid = true}
+    end
 
-  -- Tre o più uguali (1X3 = 1000, 1X4 = 2000, ...)
-  for face=1,6 do
-    if c[face] >= 3 then
-      local base = (face==1) and 1000 or face*100
-      local mult = 2^(c[face]-3)
-      points = points + base*mult
-      used[face] = used[face] + c[face] -- segna tutti come usati
+    local tripFaces = {}
+    for face = 1, 6 do
+      if c[face] == 3 then
+        tripFaces[#tripFaces + 1] = face
+      end
+    end
+    if #tripFaces == 2 then
+      for _, face in ipairs(tripFaces) do
+        use(face, 3)
+      end
+      return {points = 2500, valid = true}
+    end
+
+    local fourFace, pairFace
+    for face = 1, 6 do
+      if c[face] == 4 then
+        fourFace = face
+      elseif c[face] == 2 then
+        pairFace = face
+      end
+    end
+    if fourFace and pairFace then
+      use(fourFace, 4)
+      use(pairFace, 2)
+      points = points + 1500
     end
   end
 
-  -- 1 = 100, 5 = 50 (solo quelli non già usati da combinazioni sopra)
-  if c[1] > used[1] then
-    points = points + 100 * (c[1] - used[1])
-    used[1] = c[1]
-  end
-  if c[5] > used[5] then
-    points = points + 50 * (c[5] - used[5])
-    used[5] = c[5]
+  for face = 1, 6 do
+    local available = c[face] - used[face]
+    if available >= 3 then
+      local base = (face == 1) and 1000 or face * 100
+      local mult = 2 ^ (available - 3)
+      points = points + base * mult
+      use(face, available)
+    end
   end
 
-  return {points=points, valid=points>0}
+  for _, single in ipairs({1, 5}) do
+    local available = c[single] - used[single]
+    if available > 0 then
+      local value = single == 1 and 100 or 50
+      points = points + value * available
+      use(single, available)
+    end
+  end
+
+  local valid = points > 0
+  for face = 1, 6 do
+    if c[face] ~= used[face] then
+      valid = false
+      break
+    end
+  end
+
+  return {points = points, valid = valid}
 end
 
 function S.hasAnyScoring(roll)
-  if #roll==0 then return false end
-  local c=S.counts(roll)
-  if #roll>=6 and hasFaces(c,{1,2,3,4,5,6}) then return true end
-  if #roll>=5 and (hasFaces(c,{1,2,3,4,5}) or hasFaces(c,{2,3,4,5,6})) then return true end
-  if c[1]>0 or c[5]>0 then return true end
-  for f=1,6 do if c[f]>=3 then return true end end
+  if #roll == 0 then return false end
+  local c = S.counts(roll)
+
+  if #roll >= 6 then
+    if hasFaces(c, {1,2,3,4,5,6}) then return true end
+
+    local pairTotal = 0
+    local tripFaces = 0
+    local hasFour = false
+    local hasPair = false
+
+    for face = 1, 6 do
+      if c[face] >= 2 then
+        pairTotal = pairTotal + math.floor(c[face] / 2)
+        hasPair = true
+      end
+      if c[face] >= 3 then
+        tripFaces = tripFaces + 1
+      end
+      if c[face] >= 4 then
+        hasFour = true
+      end
+    end
+
+    if pairTotal >= 3 then return true end
+    if tripFaces >= 2 then return true end
+    if hasFour and hasPair then return true end
+  end
+
+  if c[1] > 0 or c[5] > 0 then return true end
+  for f = 1, 6 do if c[f] >= 3 then return true end end
   return false
 end
 


### PR DESCRIPTION
## Summary
- enforce official Farkle scoring combinations so selections may only include scoring dice
- update bust detection for the AI to recognize the new combinations and avoid invalid locks
- notify the player when attempting to keep non-scoring dice instead of silently ignoring the roll command

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e671b67514832789d4a76cf73ef657