### PR TITLE
Improve responsive layout, resize handling, and scoring rules

### DIFF
--- a/lib/scoring.lua
+++ b/lib/scoring.lua
@@ -8,83 +8,90 @@ end
 
 local function deepcopy(t) local r={}; for k,v in pairs(t) do r[k]=type(v)=='table' and deepcopy(v) or v end; return r end
 
-local function hasFaces(c, faces)
-  for _,f in ipairs(faces) do if c[f]==0 then return false end end
-  return true
-end
-S.hasFaces = hasFaces
-
 local function basePoints(c)
   c = deepcopy(c)
-  local pts=0
-  for f=1,6 do
-    if c[f]>=3 then
-      local base = (f==1) and 1000 or f*100
-      local mult = 2^(c[f]-3)
-      pts = pts + base*mult
-      c[f]=0
+  local pts = 0
+
+  for face = 1, 6 do
+    local count = c[face]
+    if count >= 3 then
+      local base = (face == 1) and 1000 or face * 100
+      pts = pts + base * (count - 2)
+      c[face] = 0
     end
   end
-  pts = pts + c[1]*100; c[1]=0
-  pts = pts + c[5]*50;  c[5]=0
-  local leftovers = c[2]+c[3]+c[4]+c[6]
-  return {points=pts, valid=(leftovers==0)}
+
+  if c[1] > 0 then
+    pts = pts + c[1] * 100
+    c[1] = 0
+  end
+
+  if c[5] > 0 then
+    pts = pts + c[5] * 50
+    c[5] = 0
+  end
+
+  local leftovers = c[2] + c[3] + c[4] + c[6]
+  return {points = pts, valid = leftovers == 0}
 end
 S.basePoints = basePoints
 
 function S.scoreSelection(vals)
+  if #vals == 0 then
+    return {points = 0, valid = false}
+  end
+
   local c = S.counts(vals)
   local used = {0,0,0,0,0,0,0}
   local points = 0
 
-  -- 1+2+3+4+5+6 = 1500
-  if #vals == 6 and c[1]==1 and c[2]==1 and c[3]==1 and c[4]==1 and c[5]==1 and c[6]==1 then
-    points = points + 1500
-    for i=1,6 do used[i]=used[i]+1 end
+  local function use(face, amount)
+    used[face] = used[face] + amount
   end
 
-  -- 1+2+3+4+5 = 500
-  if c[1]>=1 and c[2]>=1 and c[3]>=1 and c[4]>=1 and c[5]>=1 then
-    points = points + 500
-    for i=1,5 do used[i]=used[i]+1 end
-  end
-
-  -- 2+3+4+5+6 = 750
-  if c[2]>=1 and c[3]>=1 and c[4]>=1 and c[5]>=1 and c[6]>=1 then
-    points = points + 750
-    for i=2,6 do used[i]=used[i]+1 end
-  end
-
-  -- Tre o più uguali (1X3 = 1000, 1X4 = 2000, ...)
-  for face=1,6 do
-    if c[face] >= 3 then
-      local base = (face==1) and 1000 or face*100
-      local mult = 2^(c[face]-3)
-      points = points + base*mult
-      used[face] = used[face] + c[face] -- segna tutti come usati
+  for face = 1, 6 do
+    local available = c[face] - used[face]
+    if available >= 3 then
+      local base = (face == 1) and 1000 or face * 100
+      points = points + base * (available - 2)
+      use(face, available)
     end
   end
 
-  -- 1 = 100, 5 = 50 (solo quelli non già usati da combinazioni sopra)
-  if c[1] > used[1] then
-    points = points + 100 * (c[1] - used[1])
-    used[1] = c[1]
-  end
-  if c[5] > used[5] then
-    points = points + 50 * (c[5] - used[5])
-    used[5] = c[5]
+  for _, single in ipairs({1, 5}) do
+    local available = c[single] - used[single]
+    if available > 0 then
+      local value = single == 1 and 100 or 50
+      points = points + value * available
+      use(single, available)
+    end
   end
 
-  return {points=points, valid=points>0}
+  local valid = points > 0
+  for face = 1, 6 do
+    if c[face] ~= used[face] then
+      valid = false
+      break
+    end
+  end
+
+  return {points = points, valid = valid}
 end
 
 function S.hasAnyScoring(roll)
-  if #roll==0 then return false end
-  local c=S.counts(roll)
-  if #roll>=6 and hasFaces(c,{1,2,3,4,5,6}) then return true end
-  if #roll>=5 and (hasFaces(c,{1,2,3,4,5}) or hasFaces(c,{2,3,4,5,6})) then return true end
-  if c[1]>0 or c[5]>0 then return true end
-  for f=1,6 do if c[f]>=3 then return true end end
+  if #roll == 0 then return false end
+  local c = S.counts(roll)
+
+  if c[1] > 0 or c[5] > 0 then
+    return true
+  end
+
+  for face = 1, 6 do
+    if c[face] >= 3 then
+      return true
+    end
+  end
+
   return false
 end
 

--- a/main.lua
+++ b/main.lua
@@ -46,10 +46,39 @@ game.layout = {
     message = {},
 }
 
+local BUTTON_LABELS = {"Roll Dice", "Bank Points", "Guide", "Main Menu"}
+
 local fonts = {}
 local winningScore = 10000
 local backgroundStripes = {}
 local customCursor
+
+local function copyRect(rect)
+    if not rect then
+        return nil
+    end
+    return {x = rect.x, y = rect.y, w = rect.w, h = rect.h}
+end
+
+local function snapshotLayout()
+    return {
+        trays = {
+            ai = copyRect(game.layout.trays.ai),
+            player = copyRect(game.layout.trays.player),
+        },
+    }
+end
+
+local function realignDiceAfterLayout(oldLayout)
+    local trays = game.layout.trays
+    local previous = oldLayout and oldLayout.trays or {}
+    for id, tray in pairs(trays) do
+        local roll = game.rolls[id]
+        if roll then
+            Dice.recenterDice(roll, previous[id], tray)
+        end
+    end
+end
 
 local function getActivePlayer()
     return game.players[game.active]
@@ -76,23 +105,114 @@ local function setupStripes(height)
     end
 end
 
+local function computeHudSpacing()
+    local smallHeight = fonts.small and fonts.small:getHeight() or 22
+    local titleHeight = fonts.h2 and fonts.h2:getHeight() or 48
+    local paddingTop = math.max(24, smallHeight * 0.9)
+    local paddingBottom = math.max(28, smallHeight * 0.9)
+    local headerGap = math.max(18, smallHeight * 0.6)
+    local rowGap = math.max(16, smallHeight * 0.55)
+
+    local spacing = {
+        paddingTop = paddingTop,
+        paddingBottom = paddingBottom,
+        headerGap = headerGap,
+        rowGap = rowGap,
+        titleHeight = titleHeight,
+        headerHeight = smallHeight,
+        rowHeight = smallHeight,
+    }
+
+    spacing.totalHeight = spacing.paddingTop + spacing.titleHeight + spacing.headerGap
+        + spacing.headerHeight + spacing.rowHeight * 3 + spacing.rowGap * 3 + spacing.paddingBottom
+
+    return spacing
+end
+
 local function setupLayout(width, height)
-    -- Board centrata, ma lasciamo spazio sopra per HUD e sotto per pulsanti
-    local marginY = math.max(32, height * 0.08)
+    local marginY = math.max(32, height * 0.06)
+    if marginY * 2 >= height then
+        marginY = math.max(20, height / 2 - 8)
+    end
     local marginX = math.max(24, width * 0.05)
-    local usableHeight = height - marginY * 2 - 180 -- spazio per HUD e pulsanti
-    local boardWidth = math.min(width - marginX * 2, usableHeight * (4 / 3))
+    if marginX * 2 >= width then
+        marginX = math.max(16, width / 2 - 8)
+    end
+    local hudSpacing = computeHudSpacing()
+
+    local buttonHeight = 56
+    local buttonGap = 18
+    local panelPadding = 16
+    local buttonCount = #BUTTON_LABELS
+    local buttonColumnHeight = buttonHeight * buttonCount + buttonGap * (buttonCount - 1)
+
+    local baseButtonWidth = math.min(280, math.max(200, width * 0.18))
+    local sideSpacing = math.max(24, width * 0.03)
+    local boardAreaWidth = width - marginX * 2 - baseButtonWidth - sideSpacing
+    local minBoardAreaWidth = 520
+    local stackedLayout = boardAreaWidth < minBoardAreaWidth
+
+    local hudWidth
+    local hudX
+    local hudY = marginY
+
+    if stackedLayout then
+        hudWidth = width - marginX * 2
+        hudX = marginX
+    else
+        hudWidth = math.min(math.max(360, boardAreaWidth * 0.92), boardAreaWidth)
+        hudX = marginX + (boardAreaWidth - hudWidth) / 2
+    end
+
+    game.layout.hud = {
+        x = hudX,
+        y = hudY,
+        w = hudWidth,
+        h = hudSpacing.totalHeight,
+    }
+    game.layout.hudSpacing = hudSpacing
+
+    local hudToBoardSpacing = math.max(stackedLayout and 28 or 40, height * 0.04)
+
+    local boardWidthArea = stackedLayout and (width - marginX * 2) or boardAreaWidth
+    local messageMinHeight = math.max(110, (fonts.body and fonts.body:getHeight() or 24) * 3)
+    local buttonPanelWidth = stackedLayout and math.min(360, width - marginX * 2) or baseButtonWidth
+    local panelHeight = buttonColumnHeight + panelPadding * 2
+    local boardX
+    local boardY = hudY + hudSpacing.totalHeight + hudToBoardSpacing
+    local messageSpacing = math.max(28, height * 0.035)
+
+    local availableHeight = height - marginY - boardY - panelHeight - messageSpacing - messageMinHeight
+    if not stackedLayout then
+        availableHeight = height - marginY * 2 - hudSpacing.totalHeight - hudToBoardSpacing - messageSpacing - messageMinHeight
+    end
+    local minBoardHeight = math.max(height * 0.3, Dice.SIZE * 2.4)
+    local maxBoardHeight = math.max(availableHeight, minBoardHeight)
+
+    local boardWidth = math.min(boardWidthArea, maxBoardHeight * (4 / 3))
     local boardHeight = boardWidth * (3 / 4)
-    local boardX = (width - boardWidth) / 2
-    local boardY = marginY + 100 -- sotto l'HUD
+    if boardHeight > maxBoardHeight then
+        boardHeight = maxBoardHeight
+        boardWidth = math.min(boardWidthArea, boardHeight * (4 / 3))
+    end
+
+    boardX = (width - boardWidth) / 2
+    if not stackedLayout then
+        boardX = marginX + (boardAreaWidth - boardWidth) / 2
+    end
 
     game.layout.board = {x = boardX, y = boardY, w = boardWidth, h = boardHeight}
     game.layout.hingeY = boardY + boardHeight * 0.68
+    game.layout.mode = stackedLayout and "stacked" or "wide"
 
-    local trayWidth = boardWidth * 0.72
-    local trayHeight = boardHeight * 0.18
+    local desiredTrayWidth = stackedLayout and boardWidth * 0.66 or boardWidth * 0.72
+    local maxTrayWidth = math.max(boardWidth - 2 * (Dice.SIZE + 40), boardWidth * 0.5)
+    local trayWidth = math.min(desiredTrayWidth, maxTrayWidth)
+    trayWidth = math.max(trayWidth, Dice.SIZE * 3)
+    local trayHeight = math.max(Dice.SIZE * 1.6, boardHeight * 0.18)
+    local sideSpace = math.max(32, (boardWidth - trayWidth) / 2)
     local trayX = boardX + (boardWidth - trayWidth) / 2
-    local traySpacing = math.max(32, boardHeight * 0.08)
+    local traySpacing = math.max(stackedLayout and 28 or 32, boardHeight * 0.08)
 
     game.layout.trays.ai = {
         x = trayX,
@@ -107,47 +227,119 @@ local function setupLayout(width, height)
         h = trayHeight,
     }
 
-    local keptSpacing = math.max(96, trayWidth * 0.18)
-    game.layout.kept.ai = {
-        x = trayX - keptSpacing,
-        y = game.layout.trays.ai.y,
-        w = keptSpacing - 16,
-        h = trayHeight,
-    }
-    game.layout.kept.player = {
-        x = trayX + trayWidth + 16,
-        y = game.layout.trays.player.y,
-        w = keptSpacing - 16,
-        h = trayHeight,
-    }
+    local useStackedKept = stackedLayout and sideSpace < Dice.SIZE + 20
+    if useStackedKept then
+        local keptHeight = math.max(Dice.SIZE + 16, trayHeight * 0.75)
+        local aiY = game.layout.trays.ai.y - keptHeight - 12
+        if aiY < boardY + 12 then
+            aiY = boardY + 12
+        end
+        local playerY = game.layout.trays.player.y + trayHeight + 12
+        local maxPlayerY = boardY + boardHeight - keptHeight - 12
+        if playerY > maxPlayerY then
+            playerY = maxPlayerY
+        end
 
-    -- HUD centrato in alto
-    game.layout.hud = {
-        x = (width - 340) / 2,
-        y = marginY,
-        w = 340,
-        h = 150,
-    }
+        game.layout.kept.ai = {
+            x = trayX,
+            y = aiY,
+            w = trayWidth,
+            h = keptHeight,
+        }
+        game.layout.kept.player = {
+            x = trayX,
+            y = playerY,
+            w = trayWidth,
+            h = keptHeight,
+        }
+    else
+        local maxBySpace = math.max(24, sideSpace - 8)
+        local targetWidth = math.min(math.max(Dice.SIZE + 12, sideSpace - 12), boardWidth * 0.22)
+        local keptWidth = math.min(targetWidth, maxBySpace)
+        if maxBySpace >= Dice.SIZE + 12 then
+            keptWidth = math.max(keptWidth, Dice.SIZE + 12)
+        end
+        local keptOffset = math.max(8, (sideSpace - keptWidth) / 2)
 
-    -- Messaggio centrato sotto la board
-    game.layout.message = {
-        x = boardX + 32,
-        y = boardY + boardHeight + 16,
-        w = boardWidth - 64,
-        h = 90,
-    }
+        game.layout.kept.ai = {
+            x = boardX + keptOffset,
+            y = game.layout.trays.ai.y,
+            w = keptWidth,
+            h = trayHeight,
+        }
+        game.layout.kept.player = {
+            x = boardX + boardWidth - keptWidth - keptOffset,
+            y = game.layout.trays.player.y,
+            w = keptWidth,
+            h = trayHeight,
+        }
+    end
 
-    -- Pulsanti a destra della board, centrati verticalmente rispetto alla board
-    local buttonPanelW = 200
-    local buttonPanelH = 4 * 56 + 3 * 18
-    local buttonPanelX = boardX + boardWidth + math.max(24, width * 0.03)
-    local buttonPanelY = boardY + (boardHeight - buttonPanelH) / 2
+    local messageWidth = stackedLayout and (width - marginX * 2) or boardWidth
+    local messageX = stackedLayout and marginX or boardX
+    local messageYBase = boardY + boardHeight + messageSpacing
+
+    local panelX
+    local panelY
+    local panelW = buttonPanelWidth
+    local panelH = panelHeight
+
+    if stackedLayout then
+        panelX = (width - panelW) / 2
+        panelY = messageYBase
+        messageYBase = panelY + panelH + messageSpacing
+    else
+        panelX = marginX + boardAreaWidth + sideSpacing
+        panelY = boardY + (boardHeight - panelH) / 2
+        if panelY < marginY then
+            panelY = marginY
+        end
+        if panelY + panelH > height - marginY then
+            panelY = math.max(marginY, height - marginY - panelH)
+        end
+    end
+
+    local buttonInnerWidth = math.max(120, panelW - panelPadding * 2)
+    if buttonInnerWidth > panelW - 8 then
+        buttonInnerWidth = panelW - 8
+    end
+    local buttonOffsetX = (panelW - buttonInnerWidth) / 2
+
     game.layout.buttons = {
-        x = buttonPanelX,
-        y = buttonPanelY,
-        w = buttonPanelW,
-        h = 56,
-        spacing = 18,
+        x = panelX + buttonOffsetX,
+        y = panelY + panelPadding,
+        w = buttonInnerWidth,
+        h = buttonHeight,
+        spacing = buttonGap,
+        panel = {x = panelX, y = panelY, w = panelW, h = panelH},
+    }
+
+    local availableMessageHeight = height - messageYBase - marginY
+    local messageHeight
+    if availableMessageHeight <= 0 then
+        messageHeight = messageMinHeight
+        messageYBase = math.max(marginY, height - marginY - messageHeight)
+    else
+        messageHeight = math.max(messageMinHeight, availableMessageHeight)
+        if messageHeight > availableMessageHeight then
+            local shift = messageHeight - availableMessageHeight
+            messageYBase = math.max(marginY, messageYBase - shift)
+            availableMessageHeight = height - messageYBase - marginY
+            if availableMessageHeight > 0 and messageHeight > availableMessageHeight then
+                messageHeight = availableMessageHeight
+            elseif availableMessageHeight <= 0 then
+                messageHeight = messageMinHeight
+                messageYBase = math.max(marginY, height - marginY - messageHeight)
+            end
+        end
+    end
+
+    game.layout.message = {
+        x = messageX,
+        y = messageYBase,
+        w = messageWidth,
+        h = math.max(60, messageHeight),
+        padding = math.max(18, (fonts.body and fonts.body:getHeight() or 24) * 0.75),
     }
 end
 
@@ -309,6 +501,9 @@ local function attemptRoll()
 
     local ok = consumeSelection()
     if not ok then
+        if not getActivePlayer().isAI then
+            game.message = "Only scoring dice can be kept."
+        end
         return false
     end
     return startRoll()
@@ -449,6 +644,7 @@ end
 
 local function drawHUD()
     local hud = game.layout.hud
+    local spacing = game.layout.hudSpacing or computeHudSpacing()
     love.graphics.setColor(0.13, 0.10, 0.08, 0.92)
     love.graphics.rectangle("fill", hud.x, hud.y, hud.w, hud.h, 18, 18)
     love.graphics.setColor(0.35, 0.27, 0.18)
@@ -458,55 +654,83 @@ local function drawHUD()
     -- Titolo
     love.graphics.setFont(fonts.h2)
     love.graphics.setColor(0.98, 0.95, 0.85)
-    love.graphics.printf("SCOREBOARD", hud.x, hud.y + 8, hud.w, "center")
+    local y = hud.y + spacing.paddingTop
+    love.graphics.printf("SCOREBOARD", hud.x, y, hud.w, "center")
 
     -- Header
-    local rowY = hud.y + 44
-    local colX = {hud.x + 18, hud.x + 120, hud.x + 210, hud.x + 290}
+    y = y + spacing.titleHeight + spacing.headerGap
+    local headerY = y
+    local paddingX = math.max(18, hud.w * 0.06)
+    local availableWidth = hud.w - paddingX * 2
+    local colWidths = {
+        availableWidth * 0.38,
+        availableWidth * 0.22,
+        availableWidth * 0.20,
+        availableWidth * 0.20,
+    }
+    local colX = {
+        hud.x + paddingX,
+        hud.x + paddingX + colWidths[1],
+        hud.x + paddingX + colWidths[1] + colWidths[2],
+        hud.x + paddingX + colWidths[1] + colWidths[2] + colWidths[3],
+    }
     love.graphics.setFont(fonts.small)
     love.graphics.setColor(0.85, 0.82, 0.7)
-    love.graphics.print("Player", colX[1], rowY)
-    love.graphics.print("Banked", colX[2], rowY)
-    love.graphics.print("Round", colX[3], rowY)
-    love.graphics.print("Selected", colX[4], rowY)
+    love.graphics.print("Player", colX[1], headerY)
+    love.graphics.printf("Banked", colX[2], headerY, colWidths[2], "right")
+    love.graphics.printf("Round", colX[3], headerY, colWidths[3], "right")
+    love.graphics.printf("Selected", colX[4], headerY, colWidths[4], "right")
 
     -- Riga 1: Player
-    rowY = rowY + 28
+    local headerBottom = headerY + spacing.headerHeight
+    local rowY = headerBottom + spacing.rowGap
     love.graphics.setColor(0.7, 0.85, 1.0)
     love.graphics.print(game.players[1].name, colX[1], rowY)
     love.graphics.setColor(1, 1, 1)
-    love.graphics.printf(tostring(game.players[1].banked), colX[2], rowY, 80, "right")
+    love.graphics.printf(tostring(game.players[1].banked), colX[2], rowY, colWidths[2], "right")
     love.graphics.setColor(0.72, 0.9, 0.9)
-    love.graphics.printf(tostring(game.roundScore), colX[3], rowY, 70, "right")
+    love.graphics.printf(tostring(game.roundScore), colX[3], rowY, colWidths[3], "right")
     love.graphics.setColor(0.9, 0.75, 0.4)
-    love.graphics.printf(tostring(game.selection.points), colX[4], rowY, 60, "right")
+    love.graphics.printf(tostring(game.selection.points), colX[4], rowY, colWidths[4], "right")
 
     -- Riga 2: AI
-    rowY = rowY + 28
+    rowY = rowY + spacing.rowHeight + spacing.rowGap
     love.graphics.setColor(1.0, 0.6, 0.55)
     love.graphics.print(game.players[2].name, colX[1], rowY)
     love.graphics.setColor(1, 1, 1)
-    love.graphics.printf(tostring(game.players[2].banked), colX[2], rowY, 80, "right")
+    love.graphics.printf(tostring(game.players[2].banked), colX[2], rowY, colWidths[2], "right")
     -- Round e Selected per AI lasciati vuoti
 
+    local row2Bottom = rowY + spacing.rowHeight
+
     -- Riga 3: Goal
-    rowY = rowY + 28
+    rowY = rowY + spacing.rowHeight + spacing.rowGap
     love.graphics.setColor(0.95, 0.88, 0.45)
     love.graphics.print("Goal", colX[1], rowY)
     love.graphics.setColor(1, 1, 1)
-    love.graphics.printf(tostring(winningScore), colX[2], rowY, 80, "right")
+    love.graphics.printf(tostring(winningScore), colX[2], rowY, colWidths[2], "right")
 
     -- Separatore
     love.graphics.setColor(0.35, 0.27, 0.18, 0.7)
     love.graphics.setLineWidth(1)
-    love.graphics.line(hud.x + 12, hud.y + 40, hud.x + hud.w - 12, hud.y + 40)
-    love.graphics.line(hud.x + 12, hud.y + 100, hud.x + hud.w - 12, hud.y + 100)
+    local line1Y = headerBottom + spacing.rowGap * 0.5
+    local line2Y = row2Bottom + spacing.rowGap * 0.5
+    love.graphics.line(hud.x + 12, line1Y, hud.x + hud.w - 12, line1Y)
+    love.graphics.line(hud.x + 12, line2Y, hud.x + hud.w - 12, line2Y)
 end
 
 local function drawMessage()
+    local messageLayout = game.layout.message
+    love.graphics.setColor(0.1, 0.08, 0.06, 0.88)
+    love.graphics.rectangle("fill", messageLayout.x, messageLayout.y, messageLayout.w, messageLayout.h, 14, 14)
+    love.graphics.setColor(0.35, 0.27, 0.18)
+    love.graphics.setLineWidth(2)
+    love.graphics.rectangle("line", messageLayout.x + 4, messageLayout.y + 4, messageLayout.w - 8, messageLayout.h - 8, 12, 12)
+
     love.graphics.setFont(fonts.body)
     love.graphics.setColor(0.95, 0.92, 0.85)
-    love.graphics.printf(game.message, game.layout.message.x, game.layout.message.y, game.layout.message.w, "center")
+    local padding = messageLayout.padding or 18
+    love.graphics.printf(game.message, messageLayout.x + padding, messageLayout.y + padding, messageLayout.w - padding * 2, "center")
 end
 
 local function buttonEnabled(label)
@@ -556,9 +780,8 @@ end
 local function rebuildButtons()
     game.buttons = {}
     local layout = game.layout.buttons
-    local labels = {"Roll Dice", "Bank Points", "Guide", "Main Menu"}
     local y = layout.y
-    for _, label in ipairs(labels) do
+    for _, label in ipairs(BUTTON_LABELS) do
         local enabled = buttonEnabled(label)
         table_insert(game.buttons, {
             label = label,
@@ -574,6 +797,14 @@ end
 
 local function drawButtons()
     rebuildButtons()
+    local layout = game.layout.buttons
+    if layout.panel then
+        love.graphics.setColor(0.12, 0.09, 0.06, 0.9)
+        love.graphics.rectangle("fill", layout.panel.x, layout.panel.y, layout.panel.w, layout.panel.h, 18, 18)
+        love.graphics.setColor(0.35, 0.27, 0.18)
+        love.graphics.setLineWidth(2)
+        love.graphics.rectangle("line", layout.panel.x + 4, layout.panel.y + 4, layout.panel.w - 8, layout.panel.h - 8, 14, 14)
+    end
     for _, button in ipairs(game.buttons) do
         if button.enabled then
             love.graphics.setColor(0.34, 0.48, 0.72)
@@ -585,7 +816,11 @@ local function drawButtons()
         love.graphics.setLineWidth(2)
         love.graphics.rectangle("line", button.x, button.y, button.w, button.h, 12, 12)
         love.graphics.setFont(fonts.small)
-        love.graphics.setColor(0.95, 0.98, 1.0)
+        if button.enabled then
+            love.graphics.setColor(0.95, 0.98, 1.0)
+        else
+            love.graphics.setColor(0.65, 0.7, 0.78)
+        end
         love.graphics.printf(button.label, button.x, button.y + button.h / 2 - fonts.small:getHeight() / 2, button.w, "center")
     end
 end
@@ -813,8 +1048,8 @@ end
 function love.load()
     love.math.setRandomSeed(os.time())
     local width, height = love.graphics.getDimensions()
-    setupLayout(width, height)
     refreshFonts(width, height)
+    setupLayout(width, height)
     setupStripes(height)
     decodeCursor()
     loadSelectionImages()
@@ -837,8 +1072,8 @@ function love.draw()
     drawTray(game.layout.trays.ai)
     drawTray(game.layout.trays.player)
 
-    Dice.drawKeptColumn(game.layout.trays.ai, game.kept.ai, true, false)
-    Dice.drawKeptColumn(game.layout.trays.player, game.kept.player, false, true)
+    Dice.drawKeptColumn(game.layout.kept.ai, game.kept.ai, true)
+    Dice.drawKeptColumn(game.layout.kept.player, game.kept.player, false)
 
     drawDice()
     drawHUD()
@@ -897,7 +1132,9 @@ function love.mousepressed(x, y, button)
 end
 
 function love.resize(width, height)
-    setupLayout(width, height)
+    local previousLayout = snapshotLayout()
     refreshFonts(width, height)
+    setupLayout(width, height)
     setupStripes(height)
+    realignDiceAfterLayout(previousLayout)
 end


### PR DESCRIPTION
## Summary
- add responsive layout logic that repositions the HUD, trays, buttons, and message panel for wide and stacked window sizes
- restyle the message area and control panel while adjusting kept dice rendering to fit the new layout placements
- keep dice within their trays when the window is resized by tracking previous tray bounds
- align scoring and bust detection with the standard Farkle rules so only eligible singles and triples contribute points

## Testing
- not run (luac unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e671b67514832789d4a76cf73ef657